### PR TITLE
Fix Nested Directories in Zip

### DIFF
--- a/SAP1EMU.Engine-CLI/Makefile
+++ b/SAP1EMU.Engine-CLI/Makefile
@@ -69,17 +69,17 @@ zip:
 
 tar:
 	# OSX x64
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${OSX_RT}.tar ${PUB_DEST}/${OSX_RT}
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${OSX_RT}-self-contained.tar ${PUB_DEST}/${OSX_RT}-self-contained
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${OSX_RT}.tar -C ${PUB_DEST} ${OSX_RT}
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${OSX_RT}-self-contained.tar -C ${PUB_DEST} ${OSX_RT}-self-contained
 
 	# Linux x64
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_RT}.tar ${PUB_DEST}/${LINUX_RT}
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_RT}-self-contained.tar ${PUB_DEST}/${LINUX_RT}-self-contained
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_RT}.tar -C ${PUB_DEST} ${LINUX_RT}
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_RT}-self-contained.tar -C ${PUB_DEST} ${LINUX_RT}-self-contained
 
 	# Linux ARM
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_ARM}.tar ${PUB_DEST}/${LINUX_ARM}
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_ARM}-self-contained.tar ${PUB_DEST}/${LINUX_ARM}-self-contained
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_ARM}.tar -C ${PUB_DEST} ${LINUX_ARM}
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_ARM}-self-contained.tar -C ${PUB_DEST} ${LINUX_ARM}-self-contained
 
 	# Linux MUS -x64
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_MUSL}.tar ${PUB_DEST}/${LINUX_MUSL}
-	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_MUSL}-self-contained.tar ${PUB_DEST}/${LINUX_MUSL}-self-contained
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_MUSL}.tar -C ${PUB_DEST} ${LINUX_MUSL}
+	tar ${tar_FLAGS}  ${ZIP_DEST}/${LINUX_MUSL}-self-contained.tar -C ${PUB_DEST} ${LINUX_MUSL}-self-contained


### PR DESCRIPTION
Use -C to give tar a relative directory (via https://stackoverflow.com/a/3035446). Fix #17.

## Description
Replaced the existing `${PUB_DEST}/${RUNTIME}` arguments to `tar` with `-C ${PUB_DEST} ${RUNTIME}`. The `-C` option tells `tar` to change into the `${PUB_DEST}` directory, allowing the `${RUNTIME}` subdirectory to be specified relative to it instead of including the entire `${PUB_DEST}` parent directory.

## Motivation and Context
Fixes #17.

## How Has This Been Tested?
Since I don't have the dotnet cli installed, I created empty files in `$PUB_DEST` based on the listing under `Expected Behavior` in the bug report. I ran `make tar` before and after making this change and compared the contents of the created tarfiles.

## Screenshots (if appropriate):
Prior to change:
```
$ make tar
# OSX x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/osx.10.14-x64.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/osx.10.14-x64-self-contained.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/osx.10.14-x64-self-contained/SAP1EMU.Engine.dll
# Linux x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-x64.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-x64-self-contained.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-x64-self-contained/SAP1EMU.Engine.dll
# Linux ARM
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-arm.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-arm-self-contained.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm-self-contained/SAP1EMU.Engine.dll
# Linux MUS -x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-musl-x64.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-musl-x64-self-contained.tar SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Engine.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-musl-x64-self-contained/SAP1EMU.Engine.dll

$ tar tf $ZIP_DEST/linux-arm.tar                                                  
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/                            
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Engine.pdb          
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Assembler.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Lib.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.deps.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.runtimeconfig.json
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/CommandLine.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Assembler.pdb
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Lib.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1Emu.dll
SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/linux-arm/SAP1EMU.Engine.dll
```

After change:
```
$ make tar
# OSX x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/osx.10.14-x64.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish osx.10.14-x64
osx.10.14-x64/
osx.10.14-x64/SAP1EMU.Engine.pdb
osx.10.14-x64/SAP1EMU.Assembler.dll
osx.10.14-x64/SAP1EMU.Lib.pdb
osx.10.14-x64/SAP1Emu.deps.json
osx.10.14-x64/SAP1Emu.runtimeconfig.json
osx.10.14-x64/SAP1Emu.pdb
osx.10.14-x64/CommandLine.dll
osx.10.14-x64/SAP1EMU.Assembler.pdb
osx.10.14-x64/SAP1EMU.Lib.dll
osx.10.14-x64/SAP1Emu
osx.10.14-x64/SAP1Emu.dll
osx.10.14-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/osx.10.14-x64-self-contained.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish osx.10.14-x64-self-contained
osx.10.14-x64-self-contained/
osx.10.14-x64-self-contained/SAP1EMU.Engine.pdb
osx.10.14-x64-self-contained/SAP1EMU.Assembler.dll
osx.10.14-x64-self-contained/SAP1EMU.Lib.pdb
osx.10.14-x64-self-contained/SAP1Emu.deps.json
osx.10.14-x64-self-contained/SAP1Emu.runtimeconfig.json
osx.10.14-x64-self-contained/SAP1Emu.pdb
osx.10.14-x64-self-contained/CommandLine.dll
osx.10.14-x64-self-contained/SAP1EMU.Assembler.pdb
osx.10.14-x64-self-contained/SAP1EMU.Lib.dll
osx.10.14-x64-self-contained/SAP1Emu
osx.10.14-x64-self-contained/SAP1Emu.dll
osx.10.14-x64-self-contained/SAP1EMU.Engine.dll
# Linux x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-x64.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-x64
linux-x64/
linux-x64/SAP1EMU.Engine.pdb
linux-x64/SAP1EMU.Assembler.dll
linux-x64/SAP1EMU.Lib.pdb
linux-x64/SAP1Emu.deps.json
linux-x64/SAP1Emu.runtimeconfig.json
linux-x64/SAP1Emu.pdb
linux-x64/CommandLine.dll
linux-x64/SAP1EMU.Assembler.pdb
linux-x64/SAP1EMU.Lib.dll
linux-x64/SAP1Emu
linux-x64/SAP1Emu.dll
linux-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-x64-self-contained.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-x64-self-contained
linux-x64-self-contained/
linux-x64-self-contained/SAP1EMU.Engine.pdb
linux-x64-self-contained/SAP1EMU.Assembler.dll
linux-x64-self-contained/SAP1EMU.Lib.pdb
linux-x64-self-contained/SAP1Emu.deps.json
linux-x64-self-contained/SAP1Emu.runtimeconfig.json
linux-x64-self-contained/SAP1Emu.pdb
linux-x64-self-contained/CommandLine.dll
linux-x64-self-contained/SAP1EMU.Assembler.pdb
linux-x64-self-contained/SAP1EMU.Lib.dll
linux-x64-self-contained/SAP1Emu
linux-x64-self-contained/SAP1Emu.dll
linux-x64-self-contained/SAP1EMU.Engine.dll
# Linux ARM
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-arm.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-arm
linux-arm/
linux-arm/SAP1EMU.Engine.pdb
linux-arm/SAP1EMU.Assembler.dll
linux-arm/SAP1EMU.Lib.pdb
linux-arm/SAP1Emu.deps.json
linux-arm/SAP1Emu.runtimeconfig.json
linux-arm/SAP1Emu.pdb
linux-arm/CommandLine.dll
linux-arm/SAP1EMU.Assembler.pdb
linux-arm/SAP1EMU.Lib.dll
linux-arm/SAP1Emu
linux-arm/SAP1Emu.dll
linux-arm/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-arm-self-contained.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-arm-self-contained
linux-arm-self-contained/
linux-arm-self-contained/SAP1EMU.Engine.pdb
linux-arm-self-contained/SAP1EMU.Assembler.dll
linux-arm-self-contained/SAP1EMU.Lib.pdb
linux-arm-self-contained/SAP1Emu.deps.json
linux-arm-self-contained/SAP1Emu.runtimeconfig.json
linux-arm-self-contained/SAP1Emu.pdb
linux-arm-self-contained/CommandLine.dll
linux-arm-self-contained/SAP1EMU.Assembler.pdb
linux-arm-self-contained/SAP1EMU.Lib.dll
linux-arm-self-contained/SAP1Emu
linux-arm-self-contained/SAP1Emu.dll
linux-arm-self-contained/SAP1EMU.Engine.dll
# Linux MUS -x64
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-musl-x64.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-musl-x64
linux-musl-x64/
linux-musl-x64/SAP1EMU.Engine.pdb
linux-musl-x64/SAP1EMU.Assembler.dll
linux-musl-x64/SAP1EMU.Lib.pdb
linux-musl-x64/SAP1Emu.deps.json
linux-musl-x64/SAP1Emu.runtimeconfig.json
linux-musl-x64/SAP1Emu.pdb
linux-musl-x64/CommandLine.dll
linux-musl-x64/SAP1EMU.Assembler.pdb
linux-musl-x64/SAP1EMU.Lib.dll
linux-musl-x64/SAP1Emu
linux-musl-x64/SAP1Emu.dll
linux-musl-x64/SAP1EMU.Engine.dll
tar -cvf  SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish/output/linux-musl-x64-self-contained.tar -C SAP1EMU.Engine-CLI/bin/Release/netcoreapp3.1/publish linux-musl-x64-self-contained
linux-musl-x64-self-contained/
linux-musl-x64-self-contained/SAP1EMU.Engine.pdb
linux-musl-x64-self-contained/SAP1EMU.Assembler.dll
linux-musl-x64-self-contained/SAP1EMU.Lib.pdb
linux-musl-x64-self-contained/SAP1Emu.deps.json
linux-musl-x64-self-contained/SAP1Emu.runtimeconfig.json
linux-musl-x64-self-contained/SAP1Emu.pdb
linux-musl-x64-self-contained/CommandLine.dll
linux-musl-x64-self-contained/SAP1EMU.Assembler.pdb
linux-musl-x64-self-contained/SAP1EMU.Lib.dll
linux-musl-x64-self-contained/SAP1Emu
linux-musl-x64-self-contained/SAP1Emu.dll
linux-musl-x64-self-contained/SAP1EMU.Engine.dll

$ tar tf $ZIP_DEST/linux-arm.tar
linux-arm/
linux-arm/SAP1EMU.Engine.pdb
linux-arm/SAP1EMU.Assembler.dll
linux-arm/SAP1EMU.Lib.pdb
linux-arm/SAP1Emu.deps.json
linux-arm/SAP1Emu.runtimeconfig.json
linux-arm/SAP1Emu.pdb
linux-arm/CommandLine.dll
linux-arm/SAP1EMU.Assembler.pdb
linux-arm/SAP1EMU.Lib.dll
linux-arm/SAP1Emu
linux-arm/SAP1Emu.dll
linux-arm/SAP1EMU.Engine.dll
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
